### PR TITLE
Candle return data recovering

### DIFF
--- a/lib/ws/candle.js
+++ b/lib/ws/candle.js
@@ -9,11 +9,11 @@ const getChannelKey =
 
 const formatCandle = (candle) => ({
   timestamp: new Date(parseInt(candle[0], 10)),
-  open: new Decimal(candle[1]),
-  close: new Decimal(candle[2]),
-  high: new Decimal(candle[3]),
-  low: new Decimal(candle[4]),
-  volume: new Decimal(candle[5]),
+  volume: new Decimal(candle[1]),
+  open: new Decimal(candle[2]),
+  close: new Decimal(candle[3]),
+  high: new Decimal(candle[4]),
+  low: new Decimal(candle[5])
 })
 
 const preprocess = function(msg) {


### PR DESCRIPTION
It seems that the volume data are now after the timestamp:

https://cobinhood.github.io/api-public/#candle